### PR TITLE
 Clarify non-url usage in readme and arguments/key return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,6 @@
 
 ✂️ Sharpen your links with **vite!** API.
 
-# What?
-
-**vite!** is a [FastAPI](https://fastapi.tiangolo.com/) based API that serves 4 different endpoints:
-
-- `/encode?url=`
-- `/decode?url=` 
-
-Both of these takes an URL as argument and respectively `encode` or `decode` and return a JSON containing a 'url' key. It is not meant to be private or obfuscated, it `decode` into its database row unique id count and `encode` on a base 62.
-
-- `/determine?url=`
-
-`determine` will attempt at 'guessing' whether the request is trying to ``encode`` or ``decode`` an URL and redirect accordingly.
-
-Finally, through multiple endpoints formats:
-
-- `/redirect/`
-
-As `/redirect/` then a shortened URL, it's unique ID, or simply by appending the unique ID to the root `/` endpoint will redirect you to where an `encoded` links point to.
-
 # How?
 
 To get started and self host your **vite!** API, follow these steps:
@@ -36,6 +17,41 @@ cd vite
 pip install -r requirements.txt
 python3 start.py
 ```
+
+# Then what?
+
+**vite!** is a [FastAPI](https://fastapi.tiangolo.com/) based API that serves 4 different endpoints to get shortened links on URL or text value:
+
+### - /encode
+Takes in a `value` argument (as `/encode?value=`) that can be an URL or text and returns a JSON response containing an `url` key of the format: `https://vite.lol/` followed by a unique ID.
+
+> **Note**: The results of the encoding are predictable and not obfuscated.
+> This lets **vite!** benefits from very shorts URL for a good amount of encoding ⚡
+
+
+### - /decode
+Takes in an `url` argument (as `/decode?url=`) that can be of the following three formats:
+
+- `https://vite.lol/aB5f`
+- `vite.lol/aB5f`
+- `aB5f`
+
+And returns a JSON response containing a `value` (the original encoded URL or text) as well as a `clicks` key. `clicks` represent the amount of time your link was used by `/redirect` (refer below)
+
+
+### - /determine
+Takes in a `query` argument (as `/determine?query=`) and will attempt to redirect your query on the `/encode` or `/decode` endpoint and will return their respective result JSON.
+
+
+### - /redirect/
+Redirection is an endpoint that can explicitly be called with `/redirect/` or implicitly on `/` that can be followed by the three following format:
+
+- `https://vite.lol/aB5f`
+- `vite.lol/aB5f`
+- `aB5f`
+
+If the shortened link points on text, it will return a JSON response containing a `text` key.
+If the shortened link points to an URL, it will redirect you there.
 
 3. Voilà! As a French person, would say: "c'est allé [vite, lol](http://vite.lol/)"
 

--- a/src/codec.py
+++ b/src/codec.py
@@ -1,3 +1,5 @@
+import re
+
 from dataclasses import dataclass
 
 from .charset import URLCharset
@@ -19,6 +21,12 @@ class Codec():
     @property
     def _base(self) -> int:
         return len(self.charset)
+    
+    def is_value_url(self, value: str) -> bool:
+        """Returns True if the value matches the URL regex pattern.
+        False means the value should be treated as text."""
+        regex = r'[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)'
+        return re.match(regex, value) is not None
     
     def encode(self, id: int) -> str:
         encoded: str    = str()

--- a/src/database.py
+++ b/src/database.py
@@ -130,32 +130,26 @@ class ViteDB(DbManager):
         self.table_name = "links"
         
         self.id_key = "id"
-        self.url_key = "url"
+        self.value_key = "value"
         self.clicks_key = "clicks"
         
         self.fields = {
             f"{self.id_key}": "INTEGER PRIMARY KEY",
-            f"{self.url_key}": "TEXT NOT NULL",
+            f"{self.value_key}": "TEXT NOT NULL",
             f"{self.clicks_key}": "INTEGER DEFAULT 0"
         }
-        
-    def get_row_count(self) -> Optional[int]:
-        """Returns the number of rows in the main table."""
-        
-        sql = f"SELECT COUNT(*) FROM {self.table_name}"
-        
-        result = self.exec_get(sql, params=tuple(), all=False)
-        return None if result is None else result[0]
     
-    def insert_link(self, url: str) -> None:
-        """Inserts a new link in the database."""
+    def insert_value(self, value: str) -> int:
+        """Inserts a new URL or text value in the database and returns the row ID"""
         
         self.insert(self.table_name, 
-                    fields=(self.url_key,), 
-                    values=(url,))
+                    fields=(self.value_key,), 
+                    values=(value,))
+        
+        return self.cursor.lastrowid
         
     def increment_clicks(self, id: int) -> None:
-        """Increments the number of clicks for a given link."""
+        """Increments the number of clicks for a given shortened link ID."""
         
         # TODO: It seems like we can't have proper SQL injection protection for
         # this usecase, using self.update passes the click+1 as a string
@@ -163,12 +157,12 @@ class ViteDB(DbManager):
 
         self.exec_commit(sql, params=(id,))
         
-    def select_link(self, id: int) -> Optional[Tuple]:
-        """Returns a link from the database based on its id."""
+    def select_value(self, id: int) -> Optional[Tuple]:
+        """Returns an URL or text value from the database based on its id."""
         
         result = self.select(
             table_name = self.table_name, 
-            fields     = (self.url_key, self.clicks_key), 
+            fields     = (self.value_key, self.clicks_key), 
             conditions = (self.id_key,), 
             condition_values = (id,), 
             all        = False

--- a/src/database.py
+++ b/src/database.py
@@ -157,7 +157,7 @@ class ViteDB(DbManager):
 
         self.exec_commit(sql, params=(id,))
         
-    def select_value(self, id: int) -> Optional[Tuple]:
+    def get_value(self, id: int) -> Optional[Tuple]:
         """Returns an URL or text value from the database based on its id."""
         
         result = self.select(

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -148,4 +148,16 @@ def test_redirect_is_url():
         shortened_url = response.json()["url"]
         response = client.get(f"/redirect/{shortened_url}")
         assert response.status_code == 200
-        assert response.headers["location"] == "https://www.wikipedia.org/"
+        
+        response = client.get(f"/{shortened_url}")
+        assert response.status_code == 200
+
+def test_redirect_is_text():
+    with TestClient(app) as client:
+        response = client.get("/encode?value=Hello World!")
+        shortened_url = response.json()["url"]
+        response = client.get(f"/redirect/{shortened_url}")
+        assert response.status_code == 200
+        
+        response = client.get(f"/{shortened_url}")
+        assert response.status_code == 200

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -8,12 +8,12 @@ import src.api as api
 api.DB_PATH = "test.db"
 DB_PATH = api.DB_PATH
 
-from src.api import app, DOMAIN_NAME 
+from src.api import app, DOMAIN_NAME, SHORT_URL
 from database import ViteDB
 
 @pytest.fixture(autouse=True)
 def run_around_tests():
-    with ViteDB(DB_PATH) as db: # Creates the database
+    with ViteDB(DB_PATH) as db: # Creates the test database
         db.create_table(db.table_name, db.fields)
     yield
     os.remove(DB_PATH)
@@ -39,9 +39,9 @@ def test_boilerplate_incorrect_path():
 
 def test_empty_url():
     with TestClient(app) as client:
-        response = client.get("/encode?url=")
+        response = client.get("/encode?value=")
         assert response.status_code == 200
-        assert response.json() == {"error": "No URL provided"}
+        assert response.json() == {"error": "No URL or text provided"}
         
     with TestClient(app) as client:
         response = client.get("/decode?url=")
@@ -50,34 +50,42 @@ def test_empty_url():
 
 def test_encode():
     with TestClient(app) as client:
-        response = client.get("/encode?url=https://www.wikipedia.org/")
+        response = client.get("/encode?value=https://www.wikipedia.org/")
         assert response.status_code == 200
         response = response.json()
         assert "url" in response
         assert DOMAIN_NAME in response["url"]
         assert len(response["url"].replace(DOMAIN_NAME, "")) > 0
-        
+
+def test_encode_no_value_argument():
+    with TestClient(app) as client:
+        response = client.get("/encode")
+        assert response.status_code == 422
+          
 def test_decode():
     with TestClient(app) as client:
-        response = client.get("/encode?url=https://www.wikipedia.org/")
+        response = client.get("/encode?value=https://www.wikipedia.org/")
         shortened_url = response.json()["url"]
-        
-    with TestClient(app) as client:
         response = client.get(f"/decode?url={shortened_url}")
         assert response.status_code == 200
         response = response.json()
-        assert "url" in response
-        assert response["url"] == "https://www.wikipedia.org/"
+        assert "value" in response
+        assert response["value"] == "https://www.wikipedia.org/"
         assert "clicks" in response
         assert response["clicks"] == 0
+
+def test_decode_no_url_argument():
+    with TestClient(app) as client:
+        response = client.get("/decode")
+        assert response.status_code == 422
         
 def test_decode_0():
     with TestClient(app) as client:
         response = client.get("/decode?url=" + DOMAIN_NAME + "0")
         assert response.status_code == 200
         response = response.json()
-        assert "url" in response
-        assert response["url"] == "https://en.wikipedia.org/wiki/0#Computer_science"
+        assert "value" in response
+        assert response["value"] == "https://en.wikipedia.org/wiki/0#Computer_science"
         assert "clicks" in response
         assert response["clicks"] == -1
 
@@ -91,4 +99,53 @@ def test_decode_not_found():
     with TestClient(app) as client:
         response = client.get("/decode?url=" + DOMAIN_NAME + "1")
         assert response.status_code == 200
-        assert response.json() == {"error": "Not a valid URL"}
+        assert response.json() == {"error": "No such shortened URL found"}
+        
+def test_determine_is_encode():
+    with TestClient(app) as client:
+        response = client.get("/determine?query=https://www.wikipedia.org/")
+        assert response.status_code == 200
+        response = response.json()
+        assert "url" in response
+        assert DOMAIN_NAME in response["url"]
+        assert len(response["url"].replace(DOMAIN_NAME, "")) > 0
+        
+def test_determine_is_decode():
+    with TestClient(app) as client:
+        response = client.get("/encode?value=https://www.wikipedia.org/")
+
+        response = client.get(f"/determine?query={SHORT_URL}1")
+        assert response.status_code == 200
+        response = response.json()
+        assert "value" in response
+        assert response["value"] == "https://www.wikipedia.org/"
+        assert "clicks" in response
+        assert response["clicks"] == 0
+
+        response = client.get(f"/determine?query={DOMAIN_NAME}1")
+        assert response.status_code == 200
+        response = response.json()
+        assert "value" in response
+        assert response["value"] == "https://www.wikipedia.org/"
+        assert "clicks" in response
+        assert response["clicks"] == 0
+        
+def test_determine_fail_encode():
+    with TestClient(app) as client:
+        response = client.get("/determine?query=")
+        assert response.status_code == 200
+        assert response.json() == {"error": "No URL or text provided"}
+        
+def test_determine_fail_decode():
+    with TestClient(app) as client:
+        response = client.get("/determine?query=" + DOMAIN_NAME + "1")
+        assert response.status_code == 200
+        assert response.json() == {"error": "No such shortened URL found"}
+        
+def test_redirect_is_url():
+    with TestClient(app) as client:
+        response = client.get("/encode?value=https://www.wikipedia.org/")
+        shortened_url = response.json()["url"]
+        response = client.get(f"/redirect/{shortened_url}")
+        assert response.status_code == 200
+        assert response.headers["location"] == "https://www.wikipedia.org/"

--- a/src/tests/test_codec.py
+++ b/src/tests/test_codec.py
@@ -37,3 +37,18 @@ def test_invalid_encode_input(codec: Codec):
 def test_invalid_decode_input(codec: Codec):
     with pytest.raises(ValueError):
         codec.decode('invalid string!')
+
+def test_is_value_url_valid_url(codec: Codec):
+    assert codec.is_value_url('https://www.google.com') == True
+    assert codec.is_value_url('http://www.google.com') == True
+    assert codec.is_value_url('https://google.com') == True
+    assert codec.is_value_url('www.google.com') == True
+    assert codec.is_value_url('google.com') == True
+    assert codec.is_value_url('https://www.google.com/search?q=python') == True
+    assert codec.is_value_url('https://www.google.com/search?q=python&rlz=1C1GCEU_enUS832US832&oq=python&aqs=chrome..69i57j0l5.1234j0j7&sourceid=chrome&ie=UTF-8') == True
+    
+    
+def test_is_value_url_not_url(codec: Codec):
+    assert codec.is_value_url('Hello World!') == False
+    assert codec.is_value_url('1234567890') == False
+    assert codec.is_value_url('!@#$%^&*()') == False

--- a/src/tests/test_database.py
+++ b/src/tests/test_database.py
@@ -114,12 +114,12 @@ def test_increment_clicks():
         db.create_table(db.table_name, db.fields)
         db.insert_value("https://www.wikipedia.org/")
         db.increment_clicks(1)
-        result = db.select_value(1)
+        result = db.get_value(1)
         assert result == ("https://www.wikipedia.org/", 1)
         
-def test_select_link():
+def test_get_value():
     with ViteDB('test.db') as db:
         db.create_table(db.table_name, db.fields)
         db.insert_value("https://www.wikipedia.org/")
-        result = db.select_value(1)
+        result = db.get_value(1)
         assert result == ("https://www.wikipedia.org/", 0)

--- a/src/tests/test_database.py
+++ b/src/tests/test_database.py
@@ -96,37 +96,30 @@ def test_created_links_table():
         db.create_table(db.table_name, db.fields)
         assert (db.table_name,) in db.list_tables()
         
-def test_insert_link():
+def test_insert_value():
     with ViteDB('test.db') as db:
         db.create_table(db.table_name, db.fields)
-        db.insert_link("https://www.wikipedia.org/")
+        db.insert_value("https://www.wikipedia.org/")
         db.cursor.execute("SELECT * FROM links")
         assert db.cursor.fetchall() == [(1, "https://www.wikipedia.org/", 0)]
+
+def test_insert_value_returns_id():
+    with ViteDB('test.db') as db:
+        db.create_table(db.table_name, db.fields)
+        result = db.insert_value("https://www.wikipedia.org/")
+        assert result == 1
         
 def test_increment_clicks():
     with ViteDB('test.db') as db:
         db.create_table(db.table_name, db.fields)
-        db.insert_link("https://www.wikipedia.org/")
+        db.insert_value("https://www.wikipedia.org/")
         db.increment_clicks(1)
-        result = db.select_link(1)
+        result = db.select_value(1)
         assert result == ("https://www.wikipedia.org/", 1)
         
 def test_select_link():
     with ViteDB('test.db') as db:
         db.create_table(db.table_name, db.fields)
-        db.insert_link("https://www.wikipedia.org/")
-        result = db.select_link(1)
+        db.insert_value("https://www.wikipedia.org/")
+        result = db.select_value(1)
         assert result == ("https://www.wikipedia.org/", 0)
-        
-def test_get_row_count():
-    with ViteDB('test.db') as db:
-        db.create_table(db.table_name, db.fields)
-        assert db.get_row_count() == 0
-        db.insert_link("https://www.wikipedia.org/")
-        assert db.get_row_count() == 1
-        db.insert_link("https://www.wikipedia.org/")
-        assert db.get_row_count() == 2
-        db.delete("links", ("id",), (1,))
-        assert db.get_row_count() == 1
-        db.delete("links", ("id",), (2,))
-        assert db.get_row_count() == 0


### PR DESCRIPTION
This solves #13 in an attempt to justify the choice for **vite!** to be able to encode URL **and** text.
It wasn't clear this was intended and there was some oversight in user experience in the sense that `/redirect` would try to redirect to the text value instead of showing it. This merge request updated comments, the readme as well as the arguments for endpoint and their key value in response to better reflect this possible usage.